### PR TITLE
Add quotes around Windows command line arguments passed to JVM

### DIFF
--- a/dist/bin/scala.bat
+++ b/dist/bin/scala.bat
@@ -45,7 +45,7 @@ if "%__ARG:~0,2%"=="-D" (
 ) else if "%__ARG:~0,2%"=="-J" (
     @rem as with -D, pass to scala even though it will almost
     @rem never be used.
-    set _JAVA_ARGS=!_JAVA_ARGS! %__ARG:~2%
+    set _JAVA_ARGS=!_JAVA_ARGS! "%__ARG:~2%"
     set _SCALA_ARGS=!_SCALA_ARGS! "%__ARG%"
 ) else if "%__ARG%"=="-classpath" (
     set "_SCALA_CPATH=%~2"


### PR DESCRIPTION
Command line arguments passed to the JVM need to be quoted, otherwise some special characters, e.g. ")" will be interpreted in the script and cause it to fail.

This happened to me while testing with 3.3.3, so I would appreciate it to be fixed in 3.3.4.